### PR TITLE
Add GitHub action workflows for CI tasks

### DIFF
--- a/.github/workflows/discord-build-notifier.yml
+++ b/.github/workflows/discord-build-notifier.yml
@@ -1,0 +1,147 @@
+name: Notify Discord about build status
+
+on:
+  workflow_call:
+    inputs:
+      build_status:
+        required: true
+        type: string
+      build_number:
+        required: false
+        type: string
+        default: "???"
+      author_icon_url:
+        required: false
+        type: string
+        default: "https://avatars.githubusercontent.com/u/1390178"
+    secrets:
+      webhook_url:
+        required: true
+    outputs:
+      build_number:
+        value: ${{ jobs.notify-discord.outputs.build_number }}
+
+jobs:
+  notify-discord:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        if: inputs.build_number == '???'
+
+      - name: Get git commit description
+        # language=bash
+        run: |
+          echo "GIT_COMMIT_DESC=$(git describe --tags)" >> $GITHUB_ENV
+          echo "GIT_COMMIT_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+        if: inputs.build_number == '???'
+
+      - name: Get build number
+        id: get-build-number
+        uses: actions/github-script@v6
+        env:
+          build_number: ${{ inputs.build_number }}
+          commit_desc: ${{ env.GIT_COMMIT_DESC }}
+          commit_tag: ${{ env.GIT_COMMIT_TAG }}
+        with:
+          result-encoding: string
+          # language=js
+          script: |
+            'use strict';
+            const { build_number, commit_desc, commit_tag } = process.env
+            
+            // if we have a build number, use it.
+            if (build_number !== '???') return build_number
+            
+            // initialise fallback build number
+            let buildNumber = '???'
+            
+            // split the description. assume tag-offset-sha.
+            const splitDesc = commit_desc.split('-', 2)
+            
+            // if the split desc has more than one -, it means it probably has the info we need
+            if (splitDesc.length > 1) {
+                buildNumber = splitDesc[0] + '.' + splitDesc[1]
+            }
+            
+            return buildNumber;
+
+      - name: Create JSON embed for Discord
+        id: create-json
+        uses: actions/github-script@v6
+        env:
+          build_status: ${{ inputs.build_status }}
+          build_number: ${{ steps.get-build-number.outputs.result }}
+          ref_type: ${{ github.ref_type }}
+          ref_name: ${{ github.ref_name }}
+          author_icon_url: ${{ inputs.author_icon_url }}
+        with:
+          result-encoding: string
+          # language=js
+          script: |
+            'use strict';
+            const capitalise = (str) => str.charAt(0).toUpperCase() + str.slice(1)
+            const { build_status, build_number, ref_type, ref_name, author_icon_url } = process.env
+            
+            const title = capitalise(build_status)
+            let colour
+            switch (title) {
+                case 'Success':
+                    colour = 2684508
+                    break
+                case 'Failure':
+                case 'Cancelled':
+                    colour = 16071719
+                    break
+                case 'Started':
+                    colour = 3224808
+                    break
+            }
+            
+            const json = {
+                username: 'GitHub Actions',
+                avatar_url: 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+                embeds: [{
+                    author: {
+                        name: context.payload.repository.name,
+                        url: context.payload.repository.html_url,
+                        icon_url: `${author_icon_url}`
+                    },
+                    url: `${context.payload.repository.html_url}/actions/runs/${context.runId}`,
+                    title: `${title}`,
+                    color: `${colour}`,
+                    fields: []
+                }]
+            }
+            
+            json.embeds[0].fields.push({
+                name: 'Build number',
+                value: build_number,
+                inline: true
+            })
+            
+            json.embeds[0].fields.push({
+                name: `Build ${ref_type}`,
+                value: `${ref_name}`,
+                inline: true
+            })
+            
+            if (title === 'Started') {
+                json.embeds[0].fields.push({
+                    name: 'Commit message',
+                    value: `${context.payload.head_commit.message}`
+                })
+            }
+            
+            return JSON.stringify(json)
+
+      - name: Send notification
+        # language=bash
+        run: |
+          curl --http2-prior-knowledge --tlsv1.3 --false-start --tcp-fastopen --compressed -sS -m 10 -H "Content-Type: application/json" --request POST -d '${{ steps.create-json.outputs.result }}' ${{ env.DISCORD_WEBHOOK }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.webhook_url }}
+    outputs:
+      build_number: ${{ steps.get-build-number.outputs.result }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
         # language=bash
         run: chmod +x ./gradlew
 
-      - name: Setup Java 17
+      - name: Setup Java ${{ inputs.java }}
         # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java
         # language=bash
         run: export JAVA_HOME=$(echo $JAVA_HOME_${{ inputs.java }}_X64)

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,9 +20,8 @@ on:
         default: "net.minecraftforge"
       artifact_name:
         description: "Maven artifact"
-        required: false
+        required: true
         type: string
-        default: "forge"
       artifact_version:
         description: "Maven version"
         required: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,75 @@
+name: Gradle CI
+
+on:
+  workflow_call:
+    inputs:
+      java:
+        description: "The version of Java to use to run Gradle" # Note: Gradle's Java toolchains feature is used for compiling, which is separate from this
+        required: false
+        type: string
+        default: "17"
+      tasks:
+        description: "The Gradle tasks to run"
+        required: false
+        type: string
+        default: "publish"
+
+  workflow_dispatch:
+    inputs:
+      java:
+        description: "The version of Java to use to run Gradle"
+        required: false
+        type: choice
+        default: "17"
+        options:
+          - "21"
+          - "17"
+          - "11"
+          - "8"
+      tasks:
+        description: "The Gradle tasks to run"
+        required: false
+        type: string
+        default: "publish"
+
+permissions:
+  contents: read
+
+jobs:
+  notify-discord-start:
+    name: Notify Discord (start)
+    uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
+    with:
+      build_status: started
+    secrets:
+      webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+  gradle-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Make Gradle executable
+        # language=bash
+        run: chmod +x ./gradlew
+
+      - name: Setup Java 17
+        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java
+        # language=bash
+        run: export JAVA_HOME=$(echo $JAVA_HOME_${{ inputs.java }}_X64)
+
+      - name: Gradle ${{ inputs.tasks }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ${{ inputs.tasks }}
+
+  notify-discord-end:
+    name: Notify Discord (end)
+    needs: [ "notify-discord-start", "gradle-tasks" ]
+    if: ${{ always() }}
+    uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
+    with:
+      build_status: ${{ needs.gradle-tasks.result }}
+      build_number: ${{ needs.notify-discord-start.outputs.build_number }}
+    secrets:
+      webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,6 +22,7 @@ on:
         description: "Maven artifact"
         required: true
         type: string
+        default: "don't promote"
       artifact_version:
         description: "Maven version"
         required: false
@@ -59,7 +60,7 @@ on:
         description: "Maven artifact"
         required: false
         type: string
-        default: "forge"
+        default: "don't promote"
       promotion_type:
         description: "Promotion type"
         required: false
@@ -114,7 +115,7 @@ jobs:
   promote-artifact:
     name: Promote artifact
     needs: [ "notify-discord-start", "gradle" ]
-    if: needs.gradle.result == 'success'
+    if: needs.gradle.result == 'success' && inputs.artifact_name != "don't promote"
     uses: MinecraftForge/SharedActions/.github/workflows/promote-artifact.yml@main
     with:
       group: ${{ inputs.artifact_group }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,11 +8,31 @@ on:
         required: false
         type: string
         default: "17"
-      tasks:
+      gradle_tasks:
         description: "The Gradle tasks to run"
         required: false
         type: string
         default: "publish"
+      artifact_group:
+        description: "Maven group"
+        required: false
+        type: string
+        default: "net.minecraftforge"
+      artifact_name:
+        description: "Maven artifact"
+        required: false
+        type: string
+        default: "forge"
+      artifact_version:
+        description: "Maven version"
+        required: false
+        type: string
+        default: "???"
+      promotion_type:
+        description: "Promotion type"
+        required: false
+        type: string
+        default: "latest"
 
   workflow_dispatch:
     inputs:
@@ -26,11 +46,29 @@ on:
           - "17"
           - "11"
           - "8"
-      tasks:
+      gradle_tasks:
         description: "The Gradle tasks to run"
         required: false
         type: string
         default: "publish"
+      artifact_group:
+        description: "Maven group"
+        required: false
+        type: string
+        default: "net.minecraftforge"
+      artifact_name:
+        description: "Maven artifact"
+        required: false
+        type: string
+        default: "forge"
+      promotion_type:
+        description: "Promotion type"
+        required: false
+        type: choice
+        default: "latest"
+        options:
+          - "latest"
+          - "recommended"
 
 permissions:
   contents: read
@@ -44,7 +82,7 @@ jobs:
     secrets:
       webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
-  gradle-tasks:
+  gradle:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,18 +96,33 @@ jobs:
         # language=bash
         run: export JAVA_HOME=$(echo $JAVA_HOME_${{ inputs.java }}_X64)
 
-      - name: Gradle ${{ inputs.tasks }}
+      - name: Gradle ${{ inputs.gradle_tasks }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ${{ inputs.tasks }}
+          arguments: ${{ inputs.gradle_tasks }}
 
   notify-discord-end:
     name: Notify Discord (end)
-    needs: [ "notify-discord-start", "gradle-tasks" ]
+    needs: [ "notify-discord-start", "gradle" ]
     if: ${{ always() }}
     uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
     with:
-      build_status: ${{ needs.gradle-tasks.result }}
+      build_status: ${{ needs.gradle.result }}
       build_number: ${{ needs.notify-discord-start.outputs.build_number }}
     secrets:
       webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+  promote-artifact:
+    name: Promote artifact
+    needs: [ "notify-discord-start", "gradle" ]
+    if: needs.gradle.result == 'success'
+    uses: MinecraftForge/SharedActions/.github/workflows/promote-artifact.yml@main
+    with:
+      group: ${{ inputs.artifact_group }}
+      artifact: ${{ inputs.artifact_name }}
+      version: ${{ needs.notify-discord-start.outputs.build_number }}
+      type: ${{ inputs.promotion_type }}
+    secrets:
+      webhook_url: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK_URL }}
+      username: ${{ secrets.PROMOTE_ARTIFACT_USERNAME }}
+      password: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}

--- a/.github/workflows/promote-artifact.yml
+++ b/.github/workflows/promote-artifact.yml
@@ -1,0 +1,96 @@
+name: Promote artifact
+
+on:
+  workflow_call:
+    inputs:
+      group:
+        description: "Maven group"
+        required: true
+        type: string
+      artifact:
+        description: "Maven artifact"
+        required: true
+        type: string
+      version:
+        description: "Maven version"
+        required: true
+        type: string
+      type:
+        description: "Promotion type"
+        required: false
+        type: string
+        default: "latest"
+    secrets:
+      webhook_url:
+        required: true
+      username:
+        required: true
+      password:
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      group:
+        description: "Maven group"
+        required: true
+        type: string
+      artifact:
+        description: "Maven artifact"
+        required: true
+        type: string
+      version:
+        description: "Maven version"
+        required: true
+        type: string
+      type:
+        description: "Promotion type"
+        required: false
+        type: choice
+        default: "latest"
+        options:
+          - "latest"
+          - "recommended"
+    secrets:
+      webhook_url:
+        required: true
+      username:
+        required: true
+      password:
+        required: true
+
+jobs:
+  promote-artifact:
+    name: Promote artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create JSON
+        id: create-json
+        uses: actions/github-script@v6
+        env:
+          group: ${{ inputs.group }}
+          artifact: ${{ inputs.artifact }}
+          version: ${{ inputs.version }}
+          type: ${{ inputs.type }}
+        with:
+          result-encoding: string
+          # language=js
+          script: |
+            'use strict';
+            const { group, artifact, version, type } = process.env
+            const json = {
+              group: `${group}`,
+              artifact: `${artifact}`,
+              version: `${version}`,
+              type: `${type}`
+            }
+            
+            return JSON.stringify(json)
+
+      - name: Notify webhook
+        # language=bash
+        run: |
+          curl --tlsv1.3 --compressed -sS -m 10 -u "${{ env.USERNAME }}:${{ env.PASSWORD }}" -H "Content-Type: application/json" --request POST -d '${{ steps.create-json.outputs.result }}' ${{ env.PAGEGEN_WEBHOOK_URL }}
+        env:
+          PAGEGEN_WEBHOOK_URL: ${{ secrets.webhook_url }}
+          USERNAME: ${{ secrets.username }}
+          PASSWORD: ${{ secrets.password }}


### PR DESCRIPTION
Basic usage:
```yml
name: Publish

on:
  push:
    branches: [ "master" ]

permissions:
  contents: read

jobs:
  build:
    uses: MinecraftForge/SharedActions/.github/workflows/gradle.yml@main
    with:
      java: 17
```
Needs secrets setup on either repo or org for `DISCORD_WEBHOOK_URL`

Discord notifications look like this:
<img width="227" alt="image" src="https://github.com/MinecraftForge/SharedActions/assets/3158390/d75da565-be7c-4feb-9c12-8b02be77f8fd">