### PR TITLE
Support promoting multiple artifacts at once

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -108,7 +108,7 @@ jobs:
   promote-artifact:
     name: Promote artifact
     needs: [ "notify-discord-start", "gradle" ]
-    if: needs.gradle.result == 'success' && inputs.artifact_name != 'dont promote'
+    if: needs.gradle.result == 'success' && inputs.artifact_name != 'dont promote' && inputs.artifact_names == ''
     uses: MinecraftForge/SharedActions/.github/workflows/promote-artifact.yml@main
     with:
       group: ${{ inputs.artifact_group }}
@@ -123,7 +123,7 @@ jobs:
   promote-artifacts:
     name: Promote artifacts
     needs: [ "notify-discord-start", "gradle" ]
-    if: needs.gradle.result == 'success' && inputs.artifact_name == "don't promote" && input.artifact_names != ''
+    if: needs.gradle.result == 'success' && inputs.artifact_name == 'dont promote' && inputs.artifact_names != ''
     uses: MinecraftForge/SharedActions/.github/workflows/promote-artifacts.yml@main
     with:
       groups: ${{ inputs.artifact_groups }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,6 +23,16 @@ on:
         required: false
         type: string
         default: "dont promote"
+      artifact_groups:
+        description: "Maven groups CSV for multi-promotion. If only one group is specified, it will be used for all artifacts."
+        required: false
+        type: string
+        default: "net.minecraftforge"
+      artifact_names:
+        description: "Maven artifacts CSV for multi-promotion"
+        required: false
+        type: string
+        default: ""
       artifact_version:
         description: "Maven version"
         required: false
@@ -109,3 +119,18 @@ jobs:
       PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}
       PROMOTE_ARTIFACT_USERNAME: ${{ secrets.PROMOTE_ARTIFACT_USERNAME }}
       PROMOTE_ARTIFACT_PASSWORD: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}
+
+  promote-artifacts:
+    name: Promote artifacts
+    needs: [ "notify-discord-start", "gradle" ]
+    if: needs.gradle.result == 'success' && inputs.artifact_name == "don't promote" && input.artifact_names != ''
+    uses: MinecraftForge/SharedActions/.github/workflows/promote-artifacts.yml@main
+    with:
+      groups: ${{ inputs.artifact_groups }}
+      artifacts: ${{ inputs.artifact_names }}
+      version: ${{ needs.notify-discord-start.outputs.build_number }}
+      type: ${{ inputs.promotion_type }}
+    secrets:
+      webhook_url: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK_URL }}
+      username: ${{ secrets.PROMOTE_ARTIFACT_USERNAME }}
+      password: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}

--- a/.github/workflows/promote-artifacts.yml
+++ b/.github/workflows/promote-artifacts.yml
@@ -1,0 +1,116 @@
+name: Promote artifacts
+
+on:
+  workflow_call:
+    inputs:
+      groups:
+        description: "Maven groups CSV. If only one group is specified, it will be used for all artifacts."
+        required: true
+        type: string
+      artifacts:
+        description: "Maven artifacts CSV"
+        required: true
+        type: string
+      version:
+        description: "Maven version"
+        required: true
+        type: string
+      type:
+        description: "Promotion type"
+        required: false
+        type: string
+        default: "latest"
+    secrets:
+      PROMOTE_ARTIFACT_WEBHOOK:
+        required: true
+      PROMOTE_ARTIFACT_USERNAME:
+        required: true
+      PROMOTE_ARTIFACT_PASSWORD:
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      groups:
+        description: "Maven groups CSV. If only one group is specified, it will be used for all artifacts."
+        required: true
+        type: string
+      artifacts:
+        description: "Maven artifacts CSV"
+        required: true
+        type: string
+      version:
+        description: "Maven version"
+        required: true
+        type: string
+      type:
+        description: "Promotion type"
+        required: false
+        type: choice
+        default: "latest"
+        options:
+          - "latest"
+          - "recommended"
+
+jobs:
+  promote-artifact:
+    name: Promote artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create JSONs
+        id: create-jsons
+        uses: actions/github-script@v6
+        env:
+          groups: ${{ inputs.groups }}
+          artifacts: ${{ inputs.artifacts }}
+          version: ${{ inputs.version }}
+          type: ${{ inputs.type }}
+        with:
+          result-encoding: string
+          # language=js
+          script: |
+            'use strict';
+            const { version, type } = process.env
+            let { groups, artifacts } = process.env
+            groups = groups.split(',')
+            artifacts = artifacts.split(',')
+            
+            /** @type string[] */
+            const jsons = []
+            for (let i = 0; i < artifacts.length; i++) {
+              jsons.push(JSON.stringify({
+                group: `${groups[i] ?? groups[0]}`,
+                artifact: `${artifacts[i]}`,
+                version: `${version}`,
+                type: `${type}`
+              }))
+            }
+            
+            return jsons.join('UwU')
+
+      - name: Notify webhook
+        uses: actions/github-script@v6
+        env:
+          jsons: ${{ steps.create-jsons.outputs.result }}
+          PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}
+          PROMOTE_ARTIFACT_USERNAME: ${{ secrets.PROMOTE_ARTIFACT_USERNAME }}
+          PROMOTE_ARTIFACT_PASSWORD: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}
+        with:
+          # language=js
+          script: |
+            'use strict';
+            /** @type {{exec: (command: string, args?: string[]) => Promise<number>}} */
+            const actionsExec = require('@actions/exec');
+            const { jsons, PROMOTE_ARTIFACT_WEBHOOK, PROMOTE_ARTIFACT_USERNAME, PROMOTE_ARTIFACT_PASSWORD } = process.env
+            
+            /** @type string[] */
+            const jsonsList = jsons.split('UwU')
+            for (const json of jsonsList) {
+              await actionsExec.exec('curl', [
+                '--tlsv1.3', '--compressed', '-sS', '-m', '10',
+                '-u', `${PROMOTE_ARTIFACT_USERNAME}:${PROMOTE_ARTIFACT_PASSWORD}`,
+                '-H', 'Content-Type: application/json',
+                '--request', 'POST',
+                '-d', `${json}`,
+                `${PROMOTE_ARTIFACT_WEBHOOK}`
+              ])
+            }


### PR DESCRIPTION
Usage:
```yml
name: Publish

on:
  push:
    branches: [ "master" ]

permissions:
  contents: read

jobs:
  build:
    uses: MinecraftForge/SharedActions/.github/workflows/gradle.yml@main
    with:
      java: 17
      gradle_tasks: "publish"
      artifact_names: "JarJarMetadata,JarJarFilesystems,JarJarSelector"
    secrets:
      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
      PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}
      PROMOTE_ARTIFACT_USERNAME: ${{ secrets.PROMOTE_ARTIFACT_USERNAME }}
      PROMOTE_ARTIFACT_PASSWORD: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}
      MAVEN_USER: ${{ secrets.MAVEN_USER }}
      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
```

When needing to promote multiple artifacts, `artifact_name` is replaced with `artifact_names`, which takes a CSV