### PR TITLE
Escape commit messages

### DIFF
--- a/.github/workflows/discord-build-notifier.yml
+++ b/.github/workflows/discord-build-notifier.yml
@@ -132,7 +132,7 @@ jobs:
             if (title === 'Started') {
                 json.embeds[0].fields.push({
                     name: 'Commit message',
-                    value: `${context.payload.head_commit.message}`
+                    value: `${context.payload.head_commit.message}`.replaceAll("'", "\\'")
                 })
             }
             

--- a/.github/workflows/discord-build-notifier.yml
+++ b/.github/workflows/discord-build-notifier.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Get build number
         id: get-build-number
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           build_number: ${{ inputs.build_number }}
           commit_desc: ${{ env.GIT_COMMIT_DESC }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create JSON embed for Discord
         id: create-json
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           build_status: ${{ inputs.build_status }}
           build_number: ${{ steps.get-build-number.outputs.result }}

--- a/.github/workflows/promote-artifact.yml
+++ b/.github/workflows/promote-artifact.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Create JSON
         id: create-json
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           group: ${{ inputs.group }}
           artifact: ${{ inputs.artifact }}

--- a/.github/workflows/promote-artifacts.yml
+++ b/.github/workflows/promote-artifacts.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Create JSONs
         id: create-jsons
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           groups: ${{ inputs.groups }}
           artifacts: ${{ inputs.artifacts }}
@@ -88,7 +88,7 @@ jobs:
             return jsons.join('UwU')
 
       - name: Notify webhook
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           jsons: ${{ steps.create-jsons.outputs.result }}
           PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}


### PR DESCRIPTION
Fixes Discord messages failing to send due to forgetting to escape the string character.
https://github.com/MinecraftForge/SrgUtils/actions/runs/6997635359/job/19034823962