### PR TITLE
Update message used for the "EOL Forum" tag

### DIFF
--- a/configs/MinecraftForge/MinecraftForge.yaml
+++ b/configs/MinecraftForge/MinecraftForge.yaml
@@ -15,7 +15,7 @@ labelLocks:
     message: |-
       :wave: We use the issue tracker exclusively for final bug reports and feature requests.
       However, this issue appears to be better suited for the [Forge Support Forums](https://forums.minecraftforge.net/) or [Forge Discord](https://discord.minecraftforge.net/).
-      Please create a new topic on the support forum with this issue or ask in the `#tech-support` channel in the Discord server, and the conversation can continue there.
+      Please create a new topic on the support forum with this issue or ask in the `#player-support` channel in the Discord server, and the conversation can continue there.
   Spam:
     lock: true
     lockReason: "spam"
@@ -36,8 +36,8 @@ labelLocks:
     message: |-
       :wave: We use the issue tracker exclusively for final bug reports and feature requests.
       However, this issue appears to be better suited for the [Forge Support Forums](https://forums.minecraftforge.net/) or [Forge Discord](https://discord.minecraftforge.net/).
-      Please create a new topic on the support forum with this issue or ask in the `#tech-support` channel in the Discord server, and the conversation can continue there.
-      Please note that since your issue is for an unsupported version, we cannot guarantee that it will be addressed.
+      Please create a new topic on the support forum with this issue or ask in the `#player-support` channel in the Discord server, and the conversation can continue there.
+      Please note that since your issue is for version that is not under active support, we cannot guarantee that it will be addressed.
 triage:
   teamName: "triage"
   projectId: 4

--- a/configs/MinecraftForge/MinecraftForge.yaml
+++ b/configs/MinecraftForge/MinecraftForge.yaml
@@ -36,7 +36,7 @@ labelLocks:
     message: |-
       :wave: We use the issue tracker exclusively for final bug reports and feature requests.
       However, this issue appears to be better suited for the [Forge Support Forums](https://forums.minecraftforge.net/) or [Forge Discord](https://discord.minecraftforge.net/).
-      If that is not the case, please reach out on the [Forge Support Forums](https://forums.minecraftforge.net/) or the [Forge Discord](https://discord.minecraftforge.net/).
+      Please create a new topic on the support forum with this issue or ask in the `#tech-support` channel in the Discord server, and the conversation can continue there.
       Please note that since your issue is for an unsupported version, we cannot guarantee that it will be addressed.
 triage:
   teamName: "triage"

--- a/configs/MinecraftForge/MinecraftForge.yaml
+++ b/configs/MinecraftForge/MinecraftForge.yaml
@@ -35,8 +35,9 @@ labelLocks:
     close: true
     message: |-
       :wave: We use the issue tracker exclusively for final bug reports and feature requests.
-      Unfortunately, it seems like your issue is for an unsupported version.
+      However, this issue appears to be better suited for the [Forge Support Forums](https://forums.minecraftforge.net/) or [Forge Discord](https://discord.minecraftforge.net/).
       If that is not the case, please reach out on the [Forge Support Forums](https://forums.minecraftforge.net/) or the [Forge Discord](https://discord.minecraftforge.net/).
+      Please note that since your issue is for an unsupported version, we cannot guarantee that it will be addressed.
 triage:
   teamName: "triage"
   projectId: 4


### PR DESCRIPTION
The original message used for the "EOL Forum" tag on MinecraftForge is misleading considering our new support policy. This small change reflects the new tiered support system that we use, as described in the forums site. Suggestions to wording are welcome.