### PR TITLE
Fix Discord notification failing after build

### DIFF
--- a/.github/workflows/discord-build-notifier.yml
+++ b/.github/workflows/discord-build-notifier.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Work around actions/checkout#2041
         run: git fetch --tags
+        if: inputs.build_number == '???'
 
       - name: Get git commit description
         # language=bash


### PR DESCRIPTION
This PR fixes trying to fetch tags without a checked out Git repository, which happens when the build number script already has a build number (i.e. when reporting build success/failure).