### PR TITLE
[v0] Replace version calculation with GitVersion

### DIFF
--- a/.github/workflows/comment_actions.yml
+++ b/.github/workflows/comment_actions.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           gh_app_key: ${{ secrets.GH_APP_KEY }}
           gh_app_name: ${{ secrets.GH_APP_NAME }}
-          config_directory: MinecraftForge/SharedActions:configs@main
+          config_directory: MinecraftForge/SharedActions:configs@v0

--- a/.github/workflows/discord-build-notifier.yml
+++ b/.github/workflows/discord-build-notifier.yml
@@ -7,78 +7,27 @@ on:
         required: true
         type: string
       build_number:
-        required: false
+        required: true
         type: string
-        default: "???"
       author_icon_url:
         required: false
         type: string
-        default: "https://avatars.githubusercontent.com/u/1390178"
+        default: 'https://avatars.githubusercontent.com/u/1390178'
     secrets:
       DISCORD_WEBHOOK:
         required: true
-    outputs:
-      build_number:
-        value: ${{ jobs.notify-discord.outputs.build_number }}
 
 jobs:
   notify-discord:
     name: Notify Discord
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
-        if: inputs.build_number == '???'
-
-      - name: Work around actions/checkout#2041
-        run: git fetch --tags
-        if: inputs.build_number == '???'
-
-      - name: Get git commit description
-        # language=bash
-        run: |
-          echo "GIT_COMMIT_DESC=$(git describe --tags --long)" >> $GITHUB_ENV
-          echo "GIT_COMMIT_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-        if: inputs.build_number == '???'
-
-      - name: Get build number
-        id: get-build-number
-        uses: actions/github-script@v7
-        env:
-          build_number: ${{ inputs.build_number }}
-          commit_desc: ${{ env.GIT_COMMIT_DESC }}
-          commit_tag: ${{ env.GIT_COMMIT_TAG }}
-        with:
-          result-encoding: string
-          # language=js
-          script: |
-            'use strict';
-            const { build_number, commit_desc, commit_tag } = process.env
-            
-            // if we have a build number, use it.
-            if (build_number !== '???') return build_number
-            
-            // initialise fallback build number
-            let buildNumber = '???'
-            
-            // split the description. assume tag-offset-sha.
-            const splitDesc = commit_desc.split('-', 2)
-            
-            // if the split desc has more than one -, it means it probably has the info we need
-            if (splitDesc.length > 1) {
-                buildNumber = splitDesc[0] + '.' + splitDesc[1]
-            }
-            
-            return buildNumber;
-
       - name: Create JSON embed for Discord
         id: create-json
         uses: actions/github-script@v7
         env:
           build_status: ${{ inputs.build_status }}
-          build_number: ${{ steps.get-build-number.outputs.result }}
+          build_number: ${{ inputs.build_number }}
           ref_type: ${{ github.ref_type }}
           ref_name: ${{ github.ref_name }}
           author_icon_url: ${{ inputs.author_icon_url }}

--- a/.github/workflows/git-version.yml
+++ b/.github/workflows/git-version.yml
@@ -1,0 +1,53 @@
+name: Get Version
+
+on:
+  workflow_call:
+    inputs:
+      submodules:
+        description: 'Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules.'
+        required: false
+        type: string
+        default: 'false'
+    outputs:
+      build_number:
+        value: ${{ jobs.get-version.outputs.build_number }}
+
+permissions:
+  contents: read
+
+jobs:
+  get-version:
+    name: Get Version
+    runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.git-version.outputs.GIT_VERSION }}
+    steps:
+      - name: Checkout Repository
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ inputs.submodules }}
+          fetch-depth: 1000
+          fetch-tags: true
+
+      - name: Work around actions/checkout#2041
+        id: checkout-tags
+        # language=bash
+        run: git fetch --tags
+
+      - name: Setup Java 17
+        id: setup-java
+        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java
+        # We use this instead of the recommended `actions/setup-java` action because this is faster
+        # language=bash
+        run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> "$GITHUB_ENV"
+
+      - name: Download GitVersion
+        id: git-version-download
+        # language=bash
+        run: wget 'https://maven.minecraftforge.net/net/minecraftforge/git-version/0.1.0/git-version-0.1.0-fatjar.jar' -o ${{ runner.temp }}/git-version.jar
+
+      - name: Get Version using GitVersion
+        id: git-version
+        # language=bash
+        run: echo "GIT_VERSION=$(java -jar ${{ runner.temp }}/git-version.jar)" >> $GITHUB_ENV

--- a/.github/workflows/git-version.yml
+++ b/.github/workflows/git-version.yml
@@ -3,6 +3,11 @@ name: Get Version
 on:
   workflow_call:
     inputs:
+      version:
+        description: 'The version of GitVersion to use'
+        required: false
+        type: string
+        default: '0.1.2'
       submodules:
         description: 'Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules.'
         required: false
@@ -45,7 +50,7 @@ jobs:
       - name: Download GitVersion
         id: git-version-download
         # language=bash
-        run: wget 'https://maven.minecraftforge.net/net/minecraftforge/git-version/0.1.0/git-version-0.1.0-fatjar.jar' -o ${{ runner.temp }}/git-version.jar
+        run: wget 'https://maven.minecraftforge.net/net/minecraftforge/git-version/${{ inputs.version }}/git-version-${{ inputs.version }}-fatjar.jar' -o ${{ runner.temp }}/git-version.jar
 
       - name: Get Version using GitVersion
         id: git-version

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,56 +4,56 @@ on:
   workflow_call:
     inputs:
       java:
-        description: "The version of Java to use to run Gradle" # Note: Gradle's Java toolchains feature is used for compiling, which is separate from this
+        description: 'The version of Java to use to run Gradle' # Note: Gradle's Java toolchains feature is used for compiling, which is separate from this
         required: false
         type: string
-        default: "17"
+        default: '17'
       gradle_tasks:
-        description: "The Gradle tasks to run"
+        description: 'The Gradle tasks to run'
         required: false
         type: string
-        default: "publish"
+        default: 'publish'
       gradle_setup:
         description: |-
           Commands to run before executing the gradle command
         required: false
         type: string
       artifact_group:
-        description: "Maven group"
+        description: 'Maven group'
         required: false
         type: string
-        default: "net.minecraftforge"
+        default: 'net.minecraftforge'
       artifact_name:
-        description: "Maven artifact"
+        description: 'Maven artifact'
         required: false
         type: string
-        default: "dont promote"
+        default: 'dont promote'
       artifact_groups:
-        description: "Maven groups CSV for multi-promotion. If only one group is specified, it will be used for all artifacts."
+        description: 'Maven groups CSV for multi-promotion. If only one group is specified, it will be used for all artifacts.'
         required: false
         type: string
-        default: "net.minecraftforge"
+        default: 'net.minecraftforge'
       artifact_names:
-        description: "Maven artifacts CSV for multi-promotion"
+        description: 'Maven artifacts CSV for multi-promotion'
         required: false
         type: string
-        default: ""
+        default: ''
       artifact_version:
-        description: "Maven version"
+        description: 'Maven version'
         required: false
         type: string
-        default: "???"
+        default: '???'
       promotion_type:
-        description: "Promotion type"
+        description: 'Promotion type'
         required: false
         type: string
-        default: "latest"
+        default: 'latest'
       submodules:
-        description: "Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules."
+        description: 'Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules.'
         required: false
         type: string
-        default: "false"
-        
+        default: 'false'
+
     secrets:
       DISCORD_WEBHOOK:
         required: false
@@ -84,98 +84,118 @@ permissions:
   contents: read
 
 jobs:
+  git-version:
+    name: Project Version
+    uses: MinecraftForge/SharedActions/.github/workflows/git-version.yml@main
+    with:
+      submodules: ${{ inputs.submodules }}
+
   notify-discord-start:
     name: Notify Discord (start)
+    needs: [ 'git-version' ]
     uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
     with:
       build_status: started
+      build_number: ${{ needs.git-version.outputs.build_number }}
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
   gradle:
+    name: Run Gradle
+    needs: [ 'git-version' ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        id: checkout
+        uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.submodules }}
           fetch-depth: 1000
           fetch-tags: true
 
       - name: Work around actions/checkout#2041
+        id: checkout-tags
+        # language=bash
         run: git fetch --tags
 
-      - name: Make Gradle executable
+      - name: Setup Java ${{ inputs.java }}
+        id: setup-java
+        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java
+        # We use this instead of the recommended `actions/setup-java` action because this is faster
+        # language=bash
+        run: |-
+          echo "JAVA_HOME=$(echo $JAVA_HOME_${{ inputs.java }}_X64)" >> "$GITHUB_ENV"
+
+      - name: Setup Gradle Wrapper
+        id: setup-gradlew
         # language=bash
         run: chmod +x ./gradlew
 
-      - name: Setup Java ${{ inputs.java }}
-        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java
-        # language=bash
-        # We use this instead of the recommended `actions/setup-java` action because this is faster
-        run: |-
-          echo "JAVA_HOME=$(echo $JAVA_HOME_${{ inputs.java }}_X64)" >> "$GITHUB_ENV"
-            
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
-      
+
       - name: Set Maven Info
-        env: 
+        env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         if: ${{ env.MAVEN_USER != '' }}
+        # language=bash
         run: |-
           echo "MAVEN_USER=$MAVEN_USER" >> "$GITHUB_ENV"
           echo "MAVEN_PASSWORD=$MAVEN_PASSWORD" >> "$GITHUB_ENV"
-          
+
       - name: Set Signing Info
-        env: 
+        env:
           SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
           SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
           SIGN_KEYSTORE_PASSWORD: ${{ secrets.SIGN_KEYSTORE_PASSWORD }}
           SIGN_KEYSTORE_DATA: ${{ secrets.SIGN_KEYSTORE_DATA }}
         if: ${{ env.SIGN_KEY_ALIAS != '' }}
+        # language=bash
         run: |-
           echo "SIGN_KEY_ALIAS=$SIGN_KEY_ALIAS" >> "$GITHUB_ENV"
           echo "SIGN_KEY_PASSWORD=$SIGN_KEY_PASSWORD" >> "$GITHUB_ENV"
           echo "SIGN_KEYSTORE_PASSWORD=$SIGN_KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
           echo "SIGN_KEYSTORE_DATA=$SIGN_KEYSTORE_DATA" >> "$GITHUB_ENV"
-      
+
       - name: Set Gradle Publish Info
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         if: ${{ env.GRADLE_PUBLISH_KEY != '' }}
+        # language=bash
         run: |-
           echo "GRADLE_PUBLISH_KEY=$GRADLE_PUBLISH_KEY" >> "$GITHUB_ENV"
           echo "GRADLE_PUBLISH_SECRET=$GRADLE_PUBLISH_SECRET" >> "$GITHUB_ENV"
-          
+
       - name: Gradle ${{ inputs.gradle_tasks }}
+        # language=bash
         run: |-
           ${{ inputs.gradle_setup }}
           ./gradlew ${{ inputs.gradle_tasks }}
 
   notify-discord-end:
     name: Notify Discord (end)
-    needs: [ "notify-discord-start", "gradle" ]
+    needs: [ 'git-version', 'gradle' ]
     if: ${{ always() }}
     uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
     with:
       build_status: ${{ needs.gradle.result }}
-      build_number: ${{ needs.notify-discord-start.outputs.build_number }}
+      build_number: ${{ needs.git-version.outputs.build_number }}
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
   promote-artifact:
     name: Promote artifact
-    needs: [ "notify-discord-start", "gradle" ]
+    needs: [ 'git-version', 'gradle' ]
     if: needs.gradle.result == 'success' && inputs.artifact_name != 'dont promote' && inputs.artifact_names == ''
     uses: MinecraftForge/SharedActions/.github/workflows/promote-artifact.yml@main
     with:
       group: ${{ inputs.artifact_group }}
       artifact: ${{ inputs.artifact_name }}
-      version: ${{ needs.notify-discord-start.outputs.build_number }}
+      version: ${{ needs.git-version.outputs.build_number }}
       type: ${{ inputs.promotion_type }}
     secrets:
       PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}
@@ -184,13 +204,13 @@ jobs:
 
   promote-artifacts:
     name: Promote artifacts
-    needs: [ "notify-discord-start", "gradle" ]
+    needs: [ 'git-version', 'gradle' ]
     if: needs.gradle.result == 'success' && inputs.artifact_name == 'dont promote' && inputs.artifact_names != ''
     uses: MinecraftForge/SharedActions/.github/workflows/promote-artifacts.yml@main
     with:
       groups: ${{ inputs.artifact_groups }}
       artifacts: ${{ inputs.artifact_names }}
-      version: ${{ needs.notify-discord-start.outputs.build_number }}
+      version: ${{ needs.git-version.outputs.build_number }}
       type: ${{ inputs.promotion_type }}
     secrets:
       PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -86,14 +86,14 @@ permissions:
 jobs:
   git-version:
     name: Project Version
-    uses: MinecraftForge/SharedActions/.github/workflows/git-version.yml@main
+    uses: MinecraftForge/SharedActions/.github/workflows/git-version.yml@v0
     with:
       submodules: ${{ inputs.submodules }}
 
   notify-discord-start:
     name: Notify Discord (start)
     needs: [ 'git-version' ]
-    uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
+    uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@v0
     with:
       build_status: started
       build_number: ${{ needs.git-version.outputs.build_number }}
@@ -180,7 +180,7 @@ jobs:
     name: Notify Discord (end)
     needs: [ 'git-version', 'gradle' ]
     if: ${{ always() }}
-    uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@main
+    uses: MinecraftForge/SharedActions/.github/workflows/discord-build-notifier.yml@v0
     with:
       build_status: ${{ needs.gradle.result }}
       build_number: ${{ needs.git-version.outputs.build_number }}
@@ -191,7 +191,7 @@ jobs:
     name: Promote artifact
     needs: [ 'git-version', 'gradle' ]
     if: needs.gradle.result == 'success' && inputs.artifact_name != 'dont promote' && inputs.artifact_names == ''
-    uses: MinecraftForge/SharedActions/.github/workflows/promote-artifact.yml@main
+    uses: MinecraftForge/SharedActions/.github/workflows/promote-artifact.yml@v0
     with:
       group: ${{ inputs.artifact_group }}
       artifact: ${{ inputs.artifact_name }}
@@ -206,7 +206,7 @@ jobs:
     name: Promote artifacts
     needs: [ 'git-version', 'gradle' ]
     if: needs.gradle.result == 'success' && inputs.artifact_name == 'dont promote' && inputs.artifact_names != ''
-    uses: MinecraftForge/SharedActions/.github/workflows/promote-artifacts.yml@main
+    uses: MinecraftForge/SharedActions/.github/workflows/promote-artifacts.yml@v0
     with:
       groups: ${{ inputs.artifact_groups }}
       artifacts: ${{ inputs.artifact_names }}

--- a/.github/workflows/issue_actions.yml
+++ b/.github/workflows/issue_actions.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           gh_app_key: ${{ secrets.GH_APP_KEY }}
           gh_app_name: ${{ secrets.GH_APP_NAME }}
-          config_directory: MinecraftForge/SharedActions:configs@main
+          config_directory: MinecraftForge/SharedActions:configs@v0

--- a/.github/workflows/pr_actions.yml
+++ b/.github/workflows/pr_actions.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           gh_app_key: ${{ secrets.GH_APP_KEY }}
           gh_app_name: ${{ secrets.GH_APP_NAME }}
-          config_directory: MinecraftForge/SharedActions:configs@main
+          config_directory: MinecraftForge/SharedActions:configs@v0

--- a/.github/workflows/pr_review_actions.yml
+++ b/.github/workflows/pr_review_actions.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           gh_app_key: ${{ secrets.GH_APP_KEY }}
           gh_app_name: ${{ secrets.GH_APP_NAME }}
-          config_directory: MinecraftForge/SharedActions:configs@main
+          config_directory: MinecraftForge/SharedActions:configs@v0

--- a/.github/workflows/promote-artifact.yml
+++ b/.github/workflows/promote-artifact.yml
@@ -4,22 +4,22 @@ on:
   workflow_call:
     inputs:
       group:
-        description: "Maven group"
+        description: 'Maven group'
         required: true
         type: string
       artifact:
-        description: "Maven artifact"
+        description: 'Maven artifact'
         required: true
         type: string
       version:
-        description: "Maven version"
+        description: 'Maven version'
         required: true
         type: string
       type:
-        description: "Promotion type"
+        description: 'Promotion type'
         required: false
         type: string
-        default: "latest"
+        default: 'latest'
     secrets:
       PROMOTE_ARTIFACT_WEBHOOK:
         required: true
@@ -31,25 +31,25 @@ on:
   workflow_dispatch:
     inputs:
       group:
-        description: "Maven group"
+        description: 'Maven group'
         required: true
         type: string
       artifact:
-        description: "Maven artifact"
+        description: 'Maven artifact'
         required: true
         type: string
       version:
-        description: "Maven version"
+        description: 'Maven version'
         required: true
         type: string
       type:
-        description: "Promotion type"
+        description: 'Promotion type'
         required: false
         type: choice
-        default: "latest"
+        default: 'latest'
         options:
-          - "latest"
-          - "recommended"
+          - 'latest'
+          - 'recommended'
 
 jobs:
   promote-artifact:

--- a/.github/workflows/promote-artifacts.yml
+++ b/.github/workflows/promote-artifacts.yml
@@ -4,22 +4,22 @@ on:
   workflow_call:
     inputs:
       groups:
-        description: "Maven groups CSV. If only one group is specified, it will be used for all artifacts."
+        description: 'Maven groups CSV. If only one group is specified, it will be used for all artifacts.'
         required: true
         type: string
       artifacts:
-        description: "Maven artifacts CSV"
+        description: 'Maven artifacts CSV'
         required: true
         type: string
       version:
-        description: "Maven version"
+        description: 'Maven version'
         required: true
         type: string
       type:
-        description: "Promotion type"
+        description: 'Promotion type'
         required: false
         type: string
-        default: "latest"
+        default: 'latest'
     secrets:
       PROMOTE_ARTIFACT_WEBHOOK:
         required: true
@@ -31,25 +31,25 @@ on:
   workflow_dispatch:
     inputs:
       groups:
-        description: "Maven groups CSV. If only one group is specified, it will be used for all artifacts."
+        description: 'Maven groups CSV. If only one group is specified, it will be used for all artifacts.'
         required: true
         type: string
       artifacts:
-        description: "Maven artifacts CSV"
+        description: 'Maven artifacts CSV'
         required: true
         type: string
       version:
-        description: "Maven version"
+        description: 'Maven version'
         required: true
         type: string
       type:
-        description: "Promotion type"
+        description: 'Promotion type'
         required: false
         type: choice
-        default: "latest"
+        default: 'latest'
         options:
-          - "latest"
-          - "recommended"
+          - 'latest'
+          - 'recommended'
 
 jobs:
   promote-artifact:

--- a/.github/workflows/push_actions.yml
+++ b/.github/workflows/push_actions.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           gh_app_key: ${{ secrets.GH_APP_KEY }}
           gh_app_name: ${{ secrets.GH_APP_NAME }}
-          config_directory: MinecraftForge/SharedActions:configs@main
+          config_directory: MinecraftForge/SharedActions:configs@v0

--- a/configs/MinecraftForge/MinecraftForge.yaml
+++ b/configs/MinecraftForge/MinecraftForge.yaml
@@ -1,12 +1,12 @@
 labels:
-  feature: "Feature"
-  needs_rebase: "Needs Rebase"
-  lts: "LTS"
-  rendering: "Rendering"
-  assigned: "Assigned"
-  new_event: "New Event"
-  triage: "Triage"
-  latest: "1.20"
+  feature: 'Feature'
+  needs_rebase: 'Needs Rebase'
+  lts: 'LTS'
+  rendering: 'Rendering'
+  assigned: 'Assigned'
+  new_event: 'New Event'
+  triage: 'Triage'
+  latest: '1.20'
 labelLocks:
   Forum:
     lock: true
@@ -18,7 +18,7 @@ labelLocks:
       Please create a new topic on the support forum with this issue or ask in the `#player-support` channel in the Discord server, and the conversation can continue there.
   Spam:
     lock: true
-    lockReason: "spam"
+    lockReason: 'spam'
     close: true
     message: null
   Trivial:
@@ -29,7 +29,7 @@ labelLocks:
       :wave: Thank you for your contribution.
       Unfortunately, we do not accept low effort PRs, be it typo fixes or trivial code formatting changes.
       For inspiration or ideas, you can take a look at the open [issues](https://github.com/MinecraftForge/MinecraftForge/issues), or join our [Discord server](https://discord.minecraftforge.net/).
-  "EOL Forum":
+  'EOL Forum':
     lock: true
     lockReason: null
     close: true
@@ -39,5 +39,5 @@ labelLocks:
       Please create a new topic on the support forum with this issue or ask in the `#player-support` channel in the Discord server, and the conversation can continue there.
       Please note that since your issue is for version that is not under active support, we cannot guarantee that it will be addressed.
 triage:
-  teamName: "triage"
+  teamName: 'triage'
   projectId: 4


### PR DESCRIPTION
This PR replaces the version string logic with a call to GitVersion, eliminating the double logic between SharedActions and GradleUtils.

This PR is only to keep track of working progress, and will be merged once ready.