### PR TITLE
[v0] Add a way to set author icon url when using gradle.yml@v0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -70,6 +70,12 @@ on:
         type: string
         default: 'latest'
 
+     # Discord
+      author_icon_url:
+        required: false
+        type: string
+        default: 'https://avatars.githubusercontent.com/u/1390178'
+
     secrets:
       # Discord Build Notification
       DISCORD_WEBHOOK:
@@ -122,6 +128,7 @@ jobs:
       project_path: ${{ inputs.project_path }}
       build_status: started
       build_number: ${{ needs.git-version.outputs.build_number }}
+      author_icon_url: ${{ inputs.author_icon_url }}
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
@@ -242,6 +249,7 @@ jobs:
       project_path: ${{ inputs.project_path }}
       build_status: ${{ needs.gradle.result }}
       build_number: ${{ needs.git-version.outputs.build_number }}
+      author_icon_url: ${{ inputs.author_icon_url }}
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2f37bbdb-ac82-4b23-ab45-15be6ef6487c)



Example -> 

```yaml
name: Build MangoBot
on:
  push:
    branches: [ "master" ]
    paths-ignore:
      - 'README.md'
      - 'settings.gradle'

permissions:
  contents: write

jobs:
  build:
    uses: RealMangoRage/SharedActions/.github/workflows/gradle.yml@v0
    with:
      java: 22
      gradle_tasks: :runDatagen :publish
      artifact_name: "MangoBot"
      author_icon_url: "https://avatars.githubusercontent.com/u/147930550"
    secrets:
      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
      MAVEN_USER: ${{ secrets.USERNAME }}  # Reference the secret
      MAVEN_PASSWORD: ${{ secrets.PASSWORD }}  # Reference the secret
```

As seen above, this does work.